### PR TITLE
WS-001: Fix getMostRecent function

### DIFF
--- a/backend/Repositories/SightingsRepo.cs
+++ b/backend/Repositories/SightingsRepo.cs
@@ -40,7 +40,7 @@ namespace WhaleSpotting.Repositories
 
         public Sighting GetMostRecentSighting()
         {
-            return _context.Sightings.OrderBy(x => x.Date).First();
+            return _context.Sightings.OrderByDescending(x => x.Date).First();
         }
         public Sighting Create(CreateSightingRequest newSighting)
         {


### PR DESCRIPTION
The sightings were being ordered by date, and so it was returning the 'earliest' sighting rather than the most recent. Fixed now.
S